### PR TITLE
[codex] Fix Sonar workflow permissions

### DIFF
--- a/.github/workflows/generate-forecast-report.yml
+++ b/.github/workflows/generate-forecast-report.yml
@@ -38,7 +38,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   prepare:

--- a/.github/workflows/generate-forecast-report.yml
+++ b/.github/workflows/generate-forecast-report.yml
@@ -36,13 +36,12 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: read
-
 jobs:
   prepare:
     if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.issue.title, '[forecast]') || contains(join(github.event.issue.labels.*.name, ','), 'forecast-request') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       authorized: ${{ steps.auth.outputs.authorized }}
       request_json: ${{ steps.request.outputs.request_json }}

--- a/.github/workflows/generate-race-report.yml
+++ b/.github/workflows/generate-race-report.yml
@@ -38,7 +38,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   prepare:

--- a/.github/workflows/generate-race-report.yml
+++ b/.github/workflows/generate-race-report.yml
@@ -36,13 +36,12 @@ on:
           - participant-first
           - catalog-first
 
-permissions:
-  contents: read
-
 jobs:
   prepare:
     if: ${{ github.event_name == 'workflow_dispatch' || contains(join(github.event.issue.labels.*.name, ','), 'report-request') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       authorized: ${{ steps.auth.outputs.authorized }}
       request_json: ${{ steps.request.outputs.request_json }}


### PR DESCRIPTION
## Summary
- narrow GitHub Actions permissions in the forecast and race report workflows
- keep `issues: write` only on the jobs that comment on or update issues

## Why
- Sonar raised `githubactions:S8233` on both workflow files because they granted write access at workflow scope

## Validation
- reviewed the affected jobs to confirm the required job-level permissions already exist
- ran `git diff --check -- .github/workflows/generate-forecast-report.yml .github/workflows/generate-race-report.yml`
