### PR TITLE
Handle forecast provider fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ trailintel-forecast forecast \
   --site-dir ./dist/forecast-site
 ```
 
+If a comparison provider cannot cover the requested ride window, TrailIntel still
+generates the primary forecast and reports the skipped comparison source in the
+CLI output and HTML bundle.
+
 Forecast bundles contain:
 
 - `index.html`

--- a/src/trailintel/forecast/bundle.py
+++ b/src/trailintel/forecast/bundle.py
@@ -10,7 +10,8 @@ import httpx
 
 from trailintel.forecast.engine import (
     ForecastSummary,
-    build_reports,
+    SkippedComparisonProvider,
+    build_reports_with_metadata,
     summarize_report,
 )
 from trailintel.forecast.errors import InputValidationError
@@ -27,6 +28,7 @@ class ForecastBundleResult:
     site_dir: Path | None
     snapshot: dict[str, object] | None
     comparison_reports: tuple[ForecastReport, ...] = ()
+    comparison_warnings: tuple[str, ...] = ()
 
 
 def _default_title(gpx_path: str | Path) -> str:
@@ -63,7 +65,7 @@ def generate_forecast_assets(
         )
 
     resolved_title = resolve_forecast_title(gpx_path, title)
-    reports = build_reports(
+    build_result = build_reports_with_metadata(
         gpx_path=gpx_path,
         start=start,
         duration=duration,
@@ -75,10 +77,14 @@ def generate_forecast_assets(
         weatherapi_key=weatherapi_key,
         now=now,
     )
+    reports = build_result.reports
     report = reports[0]
     comparison_reports = tuple(reports[1:])
     image_path = render_report(report, output_path, title=resolved_title)
     summary = summarize_report(report)
+    comparison_warnings = tuple(
+        format_comparison_warning(item) for item in build_result.skipped_comparisons
+    )
 
     exported_site_dir: Path | None = None
     snapshot: dict[str, object] | None = None
@@ -88,6 +94,7 @@ def generate_forecast_assets(
             report=report,
             summary=summary,
             comparison_reports=comparison_reports,
+            comparison_warnings=comparison_warnings,
             generated_at=generated_at or datetime.now(UTC),
         )
         exported_site_dir = export_forecast_site(
@@ -104,4 +111,11 @@ def generate_forecast_assets(
         site_dir=exported_site_dir,
         snapshot=snapshot,
         comparison_reports=comparison_reports,
+        comparison_warnings=comparison_warnings,
     )
+
+
+def format_comparison_warning(build_warning: SkippedComparisonProvider) -> str:
+    label = build_warning.label or build_warning.provider_id
+    reason = build_warning.reason or "Unavailable for this run."
+    return f"Skipped comparison provider {label}: {reason}"

--- a/src/trailintel/forecast/cli.py
+++ b/src/trailintel/forecast/cli.py
@@ -99,6 +99,7 @@ def forecast(
                     if result.site_dir is not None
                     else ""
                 ),
+                *result.comparison_warnings,
             ]
             if line
         )

--- a/src/trailintel/forecast/engine.py
+++ b/src/trailintel/forecast/engine.py
@@ -227,7 +227,9 @@ def build_provider_report(
         client.close()
 
     aligned = align_forecasts(samples, forecasts)
-    notes = tuple(dict.fromkeys(note for forecast in forecasts for note in forecast.notes))
+    notes = tuple(
+        dict.fromkeys(note for forecast in forecasts for note in forecast.notes)
+    )
     return ForecastReport(
         provider_id=definition.provider_id,
         route=route,

--- a/src/trailintel/forecast/engine.py
+++ b/src/trailintel/forecast/engine.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Sequence
 
 import httpx
 
 from trailintel.forecast.align import align_forecasts
-from trailintel.forecast.errors import InputValidationError
+from trailintel.forecast.errors import InputValidationError, WeatherAPIError
 from trailintel.forecast.gpx_route import parse_gpx, sample_route
 from trailintel.forecast.models import ForecastReport, SampleForecast
 from trailintel.forecast.time_utils import (
@@ -30,6 +30,20 @@ class ForecastSummary:
     wettest_probability_pct: float | None
 
 
+@dataclass(frozen=True)
+class SkippedComparisonProvider:
+    provider_id: str
+    label: str
+    source_label: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ForecastBuildResult:
+    reports: list[ForecastReport]
+    skipped_comparisons: tuple[SkippedComparisonProvider, ...] = ()
+
+
 def build_report(
     *,
     gpx_path: str | Path,
@@ -42,7 +56,7 @@ def build_report(
     weatherapi_key: str | None = None,
     now: datetime | None = None,
 ) -> ForecastReport:
-    reports = build_reports(
+    result = build_reports_with_metadata(
         gpx_path=gpx_path,
         start=start,
         duration=duration,
@@ -53,7 +67,7 @@ def build_report(
         weatherapi_key=weatherapi_key,
         now=now,
     )
-    return reports[0]
+    return result.reports[0]
 
 
 def build_reports(
@@ -69,52 +83,161 @@ def build_reports(
     weatherapi_key: str | None = None,
     now: datetime | None = None,
 ) -> list[ForecastReport]:
+    return build_reports_with_metadata(
+        gpx_path=gpx_path,
+        start=start,
+        duration=duration,
+        timezone_name=timezone_name,
+        sample_minutes=sample_minutes,
+        http_client=http_client,
+        provider=provider,
+        compare_providers=compare_providers,
+        weatherapi_key=weatherapi_key,
+        now=now,
+    ).reports
+
+
+def build_reports_with_metadata(
+    *,
+    gpx_path: str | Path,
+    start: str,
+    duration: str,
+    timezone_name: str | None = None,
+    sample_minutes: int = 10,
+    http_client: httpx.Client | None = None,
+    provider: str = "open-meteo",
+    compare_providers: Sequence[str] = (),
+    weatherapi_key: str | None = None,
+    now: datetime | None = None,
+) -> ForecastBuildResult:
     start_time = parse_start_time(start, timezone_name)
     duration_delta = parse_duration(duration)
     provider_ids = normalize_provider_ids(provider, compare_providers)
-    horizon_days = min(
-        provider_definition(provider_id).horizon_days for provider_id in provider_ids
-    )
+    primary_provider = provider_ids[0]
+    horizon_days = provider_definition(primary_provider).horizon_days
     validate_forecast_window(
         start_time,
         duration_delta,
         now=now,
         horizon_days=horizon_days,
     )
+    active_compare_providers, skipped_comparisons = resolve_comparison_providers(
+        provider_ids[1:],
+        start_time=start_time,
+        duration=duration_delta,
+        now=now,
+    )
 
     route = parse_gpx(gpx_path)
     samples = sample_route(route, start_time, duration_delta, sample_minutes)
 
-    reports: list[ForecastReport] = []
-    for provider_id in provider_ids:
-        definition = provider_definition(provider_id)
-        client = create_forecast_client(
-            provider_id,
+    reports = [
+        build_provider_report(
+            provider_id=primary_provider,
+            route=route,
+            samples=samples,
+            start_time=start_time,
+            duration=duration_delta,
             http_client=http_client,
             weatherapi_key=weatherapi_key,
         )
+    ]
+    skipped = list(skipped_comparisons)
+    for provider_id in active_compare_providers:
+        definition = provider_definition(provider_id)
         try:
-            forecasts = client.fetch_hourly(samples)
-        finally:
-            client.close()
-
-        aligned = align_forecasts(samples, forecasts)
-        notes = tuple(
-            dict.fromkeys(note for forecast in forecasts for note in forecast.notes)
-        )
-        reports.append(
-            ForecastReport(
-                provider_id=definition.provider_id,
+            report = build_provider_report(
+                provider_id=provider_id,
                 route=route,
-                samples=aligned,
+                samples=samples,
                 start_time=start_time,
-                end_time=start_time + duration_delta,
                 duration=duration_delta,
-                source_label=definition.source_label,
-                notes=notes,
+                http_client=http_client,
+                weatherapi_key=weatherapi_key,
             )
-        )
-    return reports
+        except (InputValidationError, WeatherAPIError) as exc:
+            skipped.append(
+                SkippedComparisonProvider(
+                    provider_id=definition.provider_id,
+                    label=definition.label,
+                    source_label=definition.source_label,
+                    reason=str(exc),
+                )
+            )
+            continue
+        reports.append(report)
+    return ForecastBuildResult(
+        reports=reports,
+        skipped_comparisons=tuple(skipped),
+    )
+
+
+def resolve_comparison_providers(
+    provider_ids: Sequence[str],
+    *,
+    start_time: datetime,
+    duration: timedelta,
+    now: datetime | None = None,
+) -> tuple[list[str], tuple[SkippedComparisonProvider, ...]]:
+    now_utc = now.astimezone(UTC) if now is not None else datetime.now(UTC)
+    ride_end_utc = (start_time + duration).astimezone(UTC)
+
+    active: list[str] = []
+    skipped: list[SkippedComparisonProvider] = []
+    for provider_id in provider_ids:
+        definition = provider_definition(provider_id)
+        horizon_utc = now_utc + timedelta(days=definition.horizon_days)
+        if ride_end_utc > horizon_utc:
+            skipped.append(
+                SkippedComparisonProvider(
+                    provider_id=definition.provider_id,
+                    label=definition.label,
+                    source_label=definition.source_label,
+                    reason=(
+                        "Ride end exceeds this provider's "
+                        f"{definition.horizon_days}-day forecast horizon."
+                    ),
+                )
+            )
+            continue
+        active.append(definition.provider_id)
+
+    return active, tuple(skipped)
+
+
+def build_provider_report(
+    *,
+    provider_id: str,
+    route,
+    samples,
+    start_time: datetime,
+    duration: timedelta,
+    http_client: httpx.Client | None = None,
+    weatherapi_key: str | None = None,
+) -> ForecastReport:
+    definition = provider_definition(provider_id)
+    client = create_forecast_client(
+        provider_id,
+        http_client=http_client,
+        weatherapi_key=weatherapi_key,
+    )
+    try:
+        forecasts = client.fetch_hourly(samples)
+    finally:
+        client.close()
+
+    aligned = align_forecasts(samples, forecasts)
+    notes = tuple(dict.fromkeys(note for forecast in forecasts for note in forecast.notes))
+    return ForecastReport(
+        provider_id=definition.provider_id,
+        route=route,
+        samples=aligned,
+        start_time=start_time,
+        end_time=start_time + duration,
+        duration=duration,
+        source_label=definition.source_label,
+        notes=notes,
+    )
 
 
 def summarize_report(report: ForecastReport) -> ForecastSummary:

--- a/src/trailintel/forecast/site.py
+++ b/src/trailintel/forecast/site.py
@@ -142,6 +142,7 @@ def build_forecast_snapshot(
     report: ForecastReport,
     summary: ForecastSummary,
     comparison_reports: Sequence[ForecastReport] = (),
+    comparison_warnings: Sequence[str] = (),
     generated_at: datetime | None = None,
 ) -> dict[str, object]:
     stamp = (generated_at or datetime.now(UTC)).astimezone(UTC)
@@ -171,10 +172,11 @@ def build_forecast_snapshot(
         "key_moments": _build_key_moments(report),
         "sample_rows": _build_sample_rows(report),
     }
-    if comparison_reports:
+    if comparison_reports or comparison_warnings:
         snapshot["comparison"] = _build_comparison_snapshot(
             report,
             comparison_reports=comparison_reports,
+            comparison_warnings=comparison_warnings,
         )
     return snapshot
 
@@ -183,12 +185,16 @@ def _build_comparison_snapshot(
     report: ForecastReport,
     *,
     comparison_reports: Sequence[ForecastReport],
+    comparison_warnings: Sequence[str] = (),
 ) -> dict[str, object]:
     reports = [report, *comparison_reports]
-    return {
+    snapshot = {
         "primary_provider": report.provider_id,
         "providers": [_build_comparison_provider_entry(item) for item in reports],
     }
+    if comparison_warnings:
+        snapshot["warnings"] = list(comparison_warnings)
+    return snapshot
 
 
 def _build_comparison_provider_entry(report: ForecastReport) -> dict[str, object]:
@@ -445,24 +451,59 @@ def _comparison_key_moment_cards(providers: list[dict[str, object]]) -> str:
     return '<div class="section-stack">' + "".join(cards) + "</div>"
 
 
+def _comparison_warning_notice(warnings: list[str]) -> str:
+    if not warnings:
+        return ""
+    lines = "".join(
+        f"<li>{html.escape(message)}</li>" for message in warnings if message.strip()
+    )
+    if not lines:
+        return ""
+    return (
+        '<div class="empty-state"><strong>Skipped comparison sources</strong>'
+        f"<ul>{lines}</ul></div>"
+    )
+
+
 def _comparison_section(snapshot: dict[str, object]) -> str:
     comparison = snapshot.get("comparison")
     if not isinstance(comparison, dict):
         return ""
     providers = comparison.get("providers")
     if not isinstance(providers, list) or not providers:
-        return ""
+        providers = []
     typed_providers = [item for item in providers if isinstance(item, dict)]
-    if not typed_providers:
+    warnings = comparison.get("warnings")
+    typed_warnings = (
+        [str(item) for item in warnings if str(item).strip()]
+        if isinstance(warnings, list)
+        else []
+    )
+    available_comparisons = typed_providers if len(typed_providers) > 1 else []
+    comparison_count = max(len(typed_providers) - 1, 0)
+    if not available_comparisons and not typed_warnings:
         return ""
+    warning_notice = _comparison_warning_notice(typed_warnings)
+    if not available_comparisons:
+        return f"""
+      <section class="panel">
+        <div class="panel-head">
+          <h2>Provider Comparison</h2>
+          <span class="pill">0 available</span>
+        </div>
+        <p class="section-caption">The selected comparison sources could not cover the requested ride window.</p>
+        {warning_notice}
+      </section>
+    """
     return f"""
       <section class="panel">
         <div class="panel-head">
           <h2>Provider Comparison</h2>
-          <span class="pill">{len(typed_providers)} sources</span>
+          <span class="pill">{comparison_count} comparison source{"s" if comparison_count != 1 else ""}</span>
         </div>
         <p class="section-caption">Side-by-side forecast summaries across the selected providers for the same sampled route timeline.</p>
-        {_comparison_summary_table(typed_providers)}
+        {warning_notice}
+        {_comparison_summary_table(available_comparisons)}
       </section>
 
       <section class="panel">
@@ -471,7 +512,7 @@ def _comparison_section(snapshot: dict[str, object]) -> str:
           <span class="pill">Cross-source checkpoints</span>
         </div>
         <p class="section-caption">Start, coldest, windiest, wettest, and finish checkpoints shown provider by provider for quick comparison.</p>
-        {_comparison_key_moment_cards(typed_providers)}
+        {_comparison_key_moment_cards(available_comparisons)}
       </section>
     """
 

--- a/src/trailintel/forecast/weather.py
+++ b/src/trailintel/forecast/weather.py
@@ -82,6 +82,28 @@ class BaseForecastClient:
         if self._owns_client:
             self.http_client.close()
 
+    def _get_json(self, url: str, *, params: dict[str, str]) -> dict | list[dict]:
+        try:
+            response = self.http_client.get(url, params=params)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            message = response_error_message(exc.response)
+            status_code = exc.response.status_code
+            if message:
+                raise WeatherAPIError(
+                    f"Weather API request failed with HTTP {status_code}: {message}"
+                ) from exc
+            raise WeatherAPIError(
+                f"Weather API request failed with HTTP {status_code}."
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise WeatherAPIError(f"Weather API request failed: {exc}") from exc
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise WeatherAPIError("Weather API returned invalid JSON.") from exc
+
 
 class OpenMeteoClient(BaseForecastClient):
     provider_id = OPEN_METEO_PROVIDER
@@ -135,22 +157,7 @@ class OpenMeteoClient(BaseForecastClient):
         return all_forecasts
 
     def _request(self, params: dict[str, str]) -> dict | list[dict]:
-        try:
-            response = self.http_client.get(self.base_url, params=params)
-            response.raise_for_status()
-        except httpx.HTTPStatusError as exc:
-            message = response_error_message(exc.response)
-            if message:
-                raise WeatherAPIError(
-                    f"Weather API request failed with HTTP {exc.response.status_code}: {message}"
-                ) from exc
-            raise WeatherAPIError(
-                f"Weather API request failed with HTTP {exc.response.status_code}."
-            ) from exc
-        except httpx.HTTPError as exc:
-            raise WeatherAPIError(f"Weather API request failed: {exc}") from exc
-
-        payload = response.json()
+        payload = self._get_json(self.base_url, params=params)
         if isinstance(payload, dict) and payload.get("error"):
             reason = payload.get("reason", "unknown error")
             raise WeatherAPIError(f"Weather API error: {reason}")
@@ -233,22 +240,7 @@ class MetNoClient(BaseForecastClient):
         if sample.elevation_m is not None and math.isfinite(sample.elevation_m):
             params["altitude"] = f"{sample.elevation_m:.0f}"
 
-        try:
-            response = self.http_client.get(self.base_url, params=params)
-            response.raise_for_status()
-        except httpx.HTTPStatusError as exc:
-            message = response_error_message(exc.response)
-            if message:
-                raise WeatherAPIError(
-                    f"Weather API request failed with HTTP {exc.response.status_code}: {message}"
-                ) from exc
-            raise WeatherAPIError(
-                f"Weather API request failed with HTTP {exc.response.status_code}."
-            ) from exc
-        except httpx.HTTPError as exc:
-            raise WeatherAPIError(f"Weather API request failed: {exc}") from exc
-
-        payload = response.json()
+        payload = self._get_json(self.base_url, params=params)
         if isinstance(payload, dict) and payload.get("error"):
             reason = payload.get("reason", "unknown error")
             raise WeatherAPIError(f"Weather API error: {reason}")
@@ -416,22 +408,7 @@ class WeatherAPIClient(BaseForecastClient):
             "alerts": "no",
         }
 
-        try:
-            response = self.http_client.get(self.base_url, params=params)
-            response.raise_for_status()
-        except httpx.HTTPStatusError as exc:
-            message = response_error_message(exc.response)
-            if message:
-                raise WeatherAPIError(
-                    f"Weather API request failed with HTTP {exc.response.status_code}: {message}"
-                ) from exc
-            raise WeatherAPIError(
-                f"Weather API request failed with HTTP {exc.response.status_code}."
-            ) from exc
-        except httpx.HTTPError as exc:
-            raise WeatherAPIError(f"Weather API request failed: {exc}") from exc
-
-        payload = response.json()
+        payload = self._get_json(self.base_url, params=params)
         if isinstance(payload, dict) and isinstance(payload.get("error"), dict):
             error = payload["error"]
             message = error.get("message", "unknown error")

--- a/src/trailintel/forecast/weather.py
+++ b/src/trailintel/forecast/weather.py
@@ -139,6 +139,11 @@ class OpenMeteoClient(BaseForecastClient):
             response = self.http_client.get(self.base_url, params=params)
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
+            message = response_error_message(exc.response)
+            if message:
+                raise WeatherAPIError(
+                    f"Weather API request failed with HTTP {exc.response.status_code}: {message}"
+                ) from exc
             raise WeatherAPIError(
                 f"Weather API request failed with HTTP {exc.response.status_code}."
             ) from exc
@@ -232,6 +237,11 @@ class MetNoClient(BaseForecastClient):
             response = self.http_client.get(self.base_url, params=params)
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
+            message = response_error_message(exc.response)
+            if message:
+                raise WeatherAPIError(
+                    f"Weather API request failed with HTTP {exc.response.status_code}: {message}"
+                ) from exc
             raise WeatherAPIError(
                 f"Weather API request failed with HTTP {exc.response.status_code}."
             ) from exc
@@ -410,6 +420,11 @@ class WeatherAPIClient(BaseForecastClient):
             response = self.http_client.get(self.base_url, params=params)
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
+            message = response_error_message(exc.response)
+            if message:
+                raise WeatherAPIError(
+                    f"Weather API request failed with HTTP {exc.response.status_code}: {message}"
+                ) from exc
             raise WeatherAPIError(
                 f"Weather API request failed with HTTP {exc.response.status_code}."
             ) from exc
@@ -596,6 +611,28 @@ def apparent_temperature(
 
 def parse_datetime(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def response_error_message(response: httpx.Response) -> str | None:
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict):
+            message = error.get("message")
+            if isinstance(message, str) and message.strip():
+                return message.strip()
+        reason = payload.get("reason")
+        if isinstance(reason, str) and reason.strip():
+            return reason.strip()
+        message = payload.get("message")
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+
+    return None
 
 
 def chunked(

--- a/tests/forecast_test_support.py
+++ b/tests/forecast_test_support.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from trailintel.forecast.render import render_report as original_render_report
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_route.gpx"
+
+
+def make_open_meteo_payload(
+    *,
+    times: tuple[str, ...] = (
+        "2026-03-28T08:00",
+        "2026-03-28T09:00",
+        "2026-03-28T10:00",
+    ),
+    temperature_2m: tuple[float, ...] = (8, 10, 12),
+    apparent_temperature: tuple[float, ...] = (7, 9, 11),
+    wind_speed_10m: tuple[float, ...] = (12, 15, 18),
+    wind_gusts_10m: tuple[float, ...] = (18, 22, 25),
+    wind_direction_10m: tuple[float, ...] = (270, 280, 290),
+    cloud_cover: tuple[float, ...] = (25, 35, 45),
+    precipitation: tuple[float, ...] = (0.0, 0.2, 0.4),
+    precipitation_probability: tuple[float, ...] = (10, 35, 60),
+) -> dict[str, dict[str, list[Any]]]:
+    return {
+        "hourly": {
+            "time": list(times),
+            "temperature_2m": list(temperature_2m),
+            "apparent_temperature": list(apparent_temperature),
+            "wind_speed_10m": list(wind_speed_10m),
+            "wind_gusts_10m": list(wind_gusts_10m),
+            "wind_direction_10m": list(wind_direction_10m),
+            "cloud_cover": list(cloud_cover),
+            "precipitation": list(precipitation),
+            "precipitation_probability": list(precipitation_probability),
+        }
+    }
+
+
+def open_meteo_batch_response(
+    request: httpx.Request,
+    *,
+    payload: dict[str, object] | None = None,
+) -> httpx.Response:
+    if request.url.host != "api.open-meteo.com":
+        raise AssertionError(f"Unexpected forecast host: {request.url.host}")
+    latitudes = request.url.params["latitude"].split(",")
+    return httpx.Response(
+        200, json=[payload or make_open_meteo_payload()] * len(latitudes)
+    )
+
+
+def weatherapi_error_response(
+    *,
+    status_code: int = 401,
+    message: str = "API key is invalid.",
+    code: int = 2006,
+) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json={"error": {"code": code, "message": message}},
+    )
+
+
+def render_without_real_map(report, output_path, *, title=None):
+    return original_render_report(
+        report,
+        output_path,
+        title=title,
+        use_real_map=False,
+    )

--- a/tests/test_forecast_bundle.py
+++ b/tests/test_forecast_bundle.py
@@ -249,6 +249,82 @@ class ForecastBundleTests(unittest.TestCase):
             self.assertIn("MET Norway (yr.no)", html)
             self.assertIn("Open-Meteo", html)
 
+    def test_generate_forecast_assets_skips_short_horizon_comparison_provider(
+        self,
+    ) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            self.assertEqual(request.url.host, "api.open-meteo.com")
+            payload = {
+                "hourly": {
+                    "time": [
+                        "2026-03-31T08:00",
+                        "2026-03-31T09:00",
+                        "2026-03-31T10:00",
+                    ],
+                    "temperature_2m": [8, 10, 12],
+                    "apparent_temperature": [7, 9, 11],
+                    "wind_speed_10m": [12, 15, 18],
+                    "wind_gusts_10m": [18, 22, 25],
+                    "wind_direction_10m": [270, 280, 290],
+                    "cloud_cover": [25, 35, 45],
+                    "precipitation": [0.0, 0.2, 0.4],
+                    "precipitation_probability": [10, 35, 60],
+                }
+            }
+            latitudes = request.url.params["latitude"].split(",")
+            return httpx.Response(200, json=[payload for _ in latitudes])
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "forecast.png"
+            site_dir = Path(tmp) / "site"
+
+            def render_without_map(report, output_path, *, title=None):
+                return original_render_report(
+                    report,
+                    output_path,
+                    title=title,
+                    use_real_map=False,
+                )
+
+            with patch(
+                "trailintel.forecast.bundle.render_report",
+                render_without_map,
+            ):
+                result = generate_forecast_assets(
+                    gpx_path=FIXTURE,
+                    start="2026-03-31T08:00:00+00:00",
+                    duration="02:00",
+                    output_path=output,
+                    site_dir=site_dir,
+                    title="Sample Loop Forecast",
+                    provider="open-meteo",
+                    compare_providers=["weatherapi"],
+                    http_client=client,
+                    now=datetime(2026, 3, 27, 12, 0, tzinfo=UTC),
+                    generated_at=datetime(2026, 3, 27, 12, 30, tzinfo=UTC),
+                )
+
+            self.assertEqual(result.comparison_reports, ())
+            self.assertEqual(len(result.comparison_warnings), 1)
+            self.assertIn("WeatherAPI.com", result.comparison_warnings[0])
+            self.assertIn("3-day forecast horizon", result.comparison_warnings[0])
+
+            snapshot = json.loads(
+                (site_dir / "snapshot.json").read_text(encoding="utf-8")
+            )
+            comparison = snapshot.get("comparison")
+            self.assertIsInstance(comparison, dict)
+            self.assertEqual(
+                comparison["warnings"],
+                [result.comparison_warnings[0]],
+            )
+
+            html = (site_dir / "index.html").read_text(encoding="utf-8")
+            self.assertIn("Skipped comparison sources", html)
+            self.assertIn("WeatherAPI.com", html)
+
     def test_render_report_handles_sparse_and_dense_routes(self) -> None:
         import math
         from datetime import timedelta

--- a/tests/test_forecast_bundle.py
+++ b/tests/test_forecast_bundle.py
@@ -9,34 +9,19 @@ from unittest.mock import patch
 
 import httpx
 
+from tests.forecast_test_support import (
+    FIXTURE,
+    make_open_meteo_payload,
+    open_meteo_batch_response,
+    render_without_real_map,
+)
 from trailintel.forecast.bundle import generate_forecast_assets
-from trailintel.forecast.render import render_report as original_render_report
-
-FIXTURE = Path(__file__).parent / "fixtures" / "sample_route.gpx"
 
 
 class ForecastBundleTests(unittest.TestCase):
     def test_generate_forecast_assets_writes_site_bundle(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
-            payload = {
-                "hourly": {
-                    "time": [
-                        "2026-03-28T08:00",
-                        "2026-03-28T09:00",
-                        "2026-03-28T10:00",
-                    ],
-                    "temperature_2m": [8, 10, 12],
-                    "apparent_temperature": [7, 9, 11],
-                    "wind_speed_10m": [12, 15, 18],
-                    "wind_gusts_10m": [18, 22, 25],
-                    "wind_direction_10m": [270, 280, 290],
-                    "cloud_cover": [25, 35, 45],
-                    "precipitation": [0.0, 0.2, 0.4],
-                    "precipitation_probability": [10, 35, 60],
-                }
-            }
-            latitudes = request.url.params["latitude"].split(",")
-            return httpx.Response(200, json=[payload for _ in latitudes])
+            return open_meteo_batch_response(request)
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
 
@@ -45,18 +30,13 @@ class ForecastBundleTests(unittest.TestCase):
             site_dir = Path(tmp) / "site"
             captured_render: dict[str, str | None] = {}
 
-            def render_without_map(report, output_path, *, title=None):
+            def capture_render(report, output_path, *, title=None):
                 captured_render["title"] = title
-                return original_render_report(
-                    report,
-                    output_path,
-                    title=title,
-                    use_real_map=False,
-                )
+                return render_without_real_map(report, output_path, title=title)
 
             with patch(
                 "trailintel.forecast.bundle.render_report",
-                render_without_map,
+                capture_render,
             ):
                 result = generate_forecast_assets(
                     gpx_path=FIXTURE,
@@ -107,25 +87,7 @@ class ForecastBundleTests(unittest.TestCase):
     def test_generate_forecast_assets_writes_comparison_snapshot_and_html(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
             if request.url.host == "api.open-meteo.com":
-                payload = {
-                    "hourly": {
-                        "time": [
-                            "2026-03-28T08:00",
-                            "2026-03-28T09:00",
-                            "2026-03-28T10:00",
-                        ],
-                        "temperature_2m": [8, 10, 12],
-                        "apparent_temperature": [7, 9, 11],
-                        "wind_speed_10m": [12, 15, 18],
-                        "wind_gusts_10m": [18, 22, 25],
-                        "wind_direction_10m": [270, 280, 290],
-                        "cloud_cover": [25, 35, 45],
-                        "precipitation": [0.0, 0.2, 0.4],
-                        "precipitation_probability": [10, 35, 60],
-                    }
-                }
-                latitudes = request.url.params["latitude"].split(",")
-                return httpx.Response(200, json=[payload for _ in latitudes])
+                return open_meteo_batch_response(request)
 
             if request.url.host == "api.met.no":
                 payload = {
@@ -204,17 +166,9 @@ class ForecastBundleTests(unittest.TestCase):
             output = Path(tmp) / "forecast.png"
             site_dir = Path(tmp) / "site"
 
-            def render_without_map(report, output_path, *, title=None):
-                return original_render_report(
-                    report,
-                    output_path,
-                    title=title,
-                    use_real_map=False,
-                )
-
             with patch(
                 "trailintel.forecast.bundle.render_report",
-                render_without_map,
+                render_without_real_map,
             ):
                 result = generate_forecast_assets(
                     gpx_path=FIXTURE,
@@ -253,26 +207,16 @@ class ForecastBundleTests(unittest.TestCase):
         self,
     ) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
-            self.assertEqual(request.url.host, "api.open-meteo.com")
-            payload = {
-                "hourly": {
-                    "time": [
+            return open_meteo_batch_response(
+                request,
+                payload=make_open_meteo_payload(
+                    times=(
                         "2026-03-31T08:00",
                         "2026-03-31T09:00",
                         "2026-03-31T10:00",
-                    ],
-                    "temperature_2m": [8, 10, 12],
-                    "apparent_temperature": [7, 9, 11],
-                    "wind_speed_10m": [12, 15, 18],
-                    "wind_gusts_10m": [18, 22, 25],
-                    "wind_direction_10m": [270, 280, 290],
-                    "cloud_cover": [25, 35, 45],
-                    "precipitation": [0.0, 0.2, 0.4],
-                    "precipitation_probability": [10, 35, 60],
-                }
-            }
-            latitudes = request.url.params["latitude"].split(",")
-            return httpx.Response(200, json=[payload for _ in latitudes])
+                    )
+                ),
+            )
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
 
@@ -280,17 +224,9 @@ class ForecastBundleTests(unittest.TestCase):
             output = Path(tmp) / "forecast.png"
             site_dir = Path(tmp) / "site"
 
-            def render_without_map(report, output_path, *, title=None):
-                return original_render_report(
-                    report,
-                    output_path,
-                    title=title,
-                    use_real_map=False,
-                )
-
             with patch(
                 "trailintel.forecast.bundle.render_report",
-                render_without_map,
+                render_without_real_map,
             ):
                 result = generate_forecast_assets(
                     gpx_path=FIXTURE,

--- a/tests/test_forecast_cli.py
+++ b/tests/test_forecast_cli.py
@@ -88,6 +88,50 @@ class ForecastCliTests(unittest.TestCase):
         self.assertIn("Saved image", result.output)
         self.assertIn("Saved site bundle", result.output)
 
+    def test_cli_prints_comparison_warnings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "forecast.png"
+            fake_summary = ForecastSummary(
+                temperature_min_c=8.0,
+                temperature_max_c=12.0,
+                wind_max_kph=18.0,
+                precipitation_total_mm=0.4,
+                wettest_time=datetime(2026, 3, 28, 9, 0, tzinfo=UTC),
+                wettest_precipitation_mm=0.4,
+                wettest_probability_pct=60.0,
+            )
+            fake_result = ForecastBundleResult(
+                report=None,  # type: ignore[arg-type]
+                summary=fake_summary,
+                image_path=output,
+                site_dir=None,
+                snapshot=None,
+                comparison_warnings=(
+                    "Skipped comparison provider WeatherAPI.com: Ride end exceeds this provider's 3-day forecast horizon.",
+                ),
+            )
+
+            with patch(
+                "trailintel.forecast.cli.generate_forecast_assets",
+                return_value=fake_result,
+            ):
+                result = self.runner.invoke(
+                    app,
+                    [
+                        "forecast",
+                        str(FIXTURE),
+                        "--start",
+                        "2026-03-28T08:00:00+00:00",
+                        "--duration",
+                        "02:00",
+                        "--output",
+                        str(output),
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Skipped comparison provider WeatherAPI.com", result.output)
+
     def test_cli_requires_site_dir_for_compare_mode(self) -> None:
         result = self.runner.invoke(
             app,

--- a/tests/test_forecast_engine.py
+++ b/tests/test_forecast_engine.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import os
 import unittest
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from unittest.mock import patch
+
+import httpx
 
 from trailintel.forecast.engine import build_report as build_route_report
-from trailintel.forecast.engine import summarize_report
+from trailintel.forecast.engine import build_reports_with_metadata, summarize_report
 from trailintel.forecast.errors import InputValidationError
 from trailintel.forecast.models import (
     Bounds,
@@ -163,14 +167,107 @@ class ForecastEngineTests(unittest.TestCase):
             )
 
     def test_build_report_requires_weatherapi_key_before_network(self) -> None:
-        with self.assertRaisesRegex(InputValidationError, "WEATHERAPI_KEY"):
-            build_route_report(
-                gpx_path=FIXTURE,
-                start="2026-03-28T08:00:00+00:00",
-                duration="02:00",
-                provider="weatherapi",
-                now=datetime(2026, 3, 27, 12, 0, tzinfo=UTC),
-            )
+        with patch.dict(os.environ, {"WEATHERAPI_KEY": ""}):
+            with self.assertRaisesRegex(InputValidationError, "WEATHERAPI_KEY"):
+                build_route_report(
+                    gpx_path=FIXTURE,
+                    start="2026-03-28T08:00:00+00:00",
+                    duration="02:00",
+                    provider="weatherapi",
+                    now=datetime(2026, 3, 27, 12, 0, tzinfo=UTC),
+                )
+
+    def test_build_reports_skips_comparison_provider_beyond_horizon(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            self.assertEqual(request.url.host, "api.open-meteo.com")
+            payload = {
+                "hourly": {
+                    "time": [
+                        "2026-03-31T08:00",
+                        "2026-03-31T09:00",
+                        "2026-03-31T10:00",
+                    ],
+                    "temperature_2m": [8, 10, 12],
+                    "apparent_temperature": [7, 9, 11],
+                    "wind_speed_10m": [12, 15, 18],
+                    "wind_gusts_10m": [18, 22, 25],
+                    "wind_direction_10m": [270, 280, 290],
+                    "cloud_cover": [25, 35, 45],
+                    "precipitation": [0.0, 0.2, 0.4],
+                    "precipitation_probability": [10, 35, 60],
+                }
+            }
+            latitudes = request.url.params["latitude"].split(",")
+            return httpx.Response(200, json=[payload for _ in latitudes])
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+
+        result = build_reports_with_metadata(
+            gpx_path=FIXTURE,
+            start="2026-03-31T08:00:00+00:00",
+            duration="02:00",
+            provider="open-meteo",
+            compare_providers=["weatherapi"],
+            http_client=client,
+            now=datetime(2026, 3, 27, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(len(result.reports), 1)
+        self.assertEqual(result.reports[0].provider_id, "open-meteo")
+        self.assertEqual(len(result.skipped_comparisons), 1)
+        self.assertEqual(result.skipped_comparisons[0].provider_id, "weatherapi")
+        self.assertIn("3-day forecast horizon", result.skipped_comparisons[0].reason)
+
+    def test_build_reports_skips_comparison_provider_on_api_error(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.host == "api.open-meteo.com":
+                payload = {
+                    "hourly": {
+                        "time": [
+                            "2026-03-28T08:00",
+                            "2026-03-28T09:00",
+                            "2026-03-28T10:00",
+                        ],
+                        "temperature_2m": [8, 10, 12],
+                        "apparent_temperature": [7, 9, 11],
+                        "wind_speed_10m": [12, 15, 18],
+                        "wind_gusts_10m": [18, 22, 25],
+                        "wind_direction_10m": [270, 280, 290],
+                        "cloud_cover": [25, 35, 45],
+                        "precipitation": [0.0, 0.2, 0.4],
+                        "precipitation_probability": [10, 35, 60],
+                    }
+                }
+                latitudes = request.url.params["latitude"].split(",")
+                return httpx.Response(200, json=[payload for _ in latitudes])
+
+            if request.url.host == "api.weatherapi.com":
+                return httpx.Response(
+                    401,
+                    json={"error": {"code": 2006, "message": "API key is invalid."}},
+                )
+
+            raise AssertionError(f"Unexpected forecast host: {request.url.host}")
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+
+        result = build_reports_with_metadata(
+            gpx_path=FIXTURE,
+            start="2026-03-28T08:00:00+00:00",
+            duration="02:00",
+            provider="open-meteo",
+            compare_providers=["weatherapi"],
+            weatherapi_key="test-key",
+            http_client=client,
+            now=datetime(2026, 3, 27, 12, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(len(result.reports), 1)
+        self.assertEqual(result.reports[0].provider_id, "open-meteo")
+        self.assertEqual(len(result.skipped_comparisons), 1)
+        self.assertEqual(result.skipped_comparisons[0].provider_id, "weatherapi")
+        self.assertIn("HTTP 401", result.skipped_comparisons[0].reason)
+        self.assertIn("API key is invalid", result.skipped_comparisons[0].reason)
 
 
 if __name__ == "__main__":

--- a/tests/test_forecast_engine.py
+++ b/tests/test_forecast_engine.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 import os
 import unittest
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 from unittest.mock import patch
 
 import httpx
 
+from tests.forecast_test_support import (
+    FIXTURE,
+    make_open_meteo_payload,
+    open_meteo_batch_response,
+    weatherapi_error_response,
+)
 from trailintel.forecast.engine import build_report as build_route_report
 from trailintel.forecast.engine import build_reports_with_metadata, summarize_report
 from trailintel.forecast.errors import InputValidationError
@@ -19,8 +24,6 @@ from trailintel.forecast.models import (
     SampleForecast,
     SamplePoint,
 )
-
-FIXTURE = Path(__file__).parent / "fixtures" / "sample_route.gpx"
 
 
 def make_sample(
@@ -81,6 +84,25 @@ def build_report(samples: list[SampleForecast]) -> ForecastReport:
 
 
 class ForecastEngineTests(unittest.TestCase):
+    def build_open_meteo_client(
+        self,
+        *,
+        payload: dict[str, object] | None = None,
+        weatherapi_status_code: int | None = None,
+        weatherapi_message: str = "API key is invalid.",
+    ) -> httpx.Client:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.host == "api.open-meteo.com":
+                return open_meteo_batch_response(request, payload=payload)
+            if request.url.host == "api.weatherapi.com" and weatherapi_status_code:
+                return weatherapi_error_response(
+                    status_code=weatherapi_status_code,
+                    message=weatherapi_message,
+                )
+            raise AssertionError(f"Unexpected forecast host: {request.url.host}")
+
+        return httpx.Client(transport=httpx.MockTransport(handler))
+
     def test_summarize_report_prefers_highest_rain_amount_over_probability(
         self,
     ) -> None:
@@ -178,29 +200,15 @@ class ForecastEngineTests(unittest.TestCase):
                 )
 
     def test_build_reports_skips_comparison_provider_beyond_horizon(self) -> None:
-        def handler(request: httpx.Request) -> httpx.Response:
-            self.assertEqual(request.url.host, "api.open-meteo.com")
-            payload = {
-                "hourly": {
-                    "time": [
-                        "2026-03-31T08:00",
-                        "2026-03-31T09:00",
-                        "2026-03-31T10:00",
-                    ],
-                    "temperature_2m": [8, 10, 12],
-                    "apparent_temperature": [7, 9, 11],
-                    "wind_speed_10m": [12, 15, 18],
-                    "wind_gusts_10m": [18, 22, 25],
-                    "wind_direction_10m": [270, 280, 290],
-                    "cloud_cover": [25, 35, 45],
-                    "precipitation": [0.0, 0.2, 0.4],
-                    "precipitation_probability": [10, 35, 60],
-                }
-            }
-            latitudes = request.url.params["latitude"].split(",")
-            return httpx.Response(200, json=[payload for _ in latitudes])
-
-        client = httpx.Client(transport=httpx.MockTransport(handler))
+        client = self.build_open_meteo_client(
+            payload=make_open_meteo_payload(
+                times=(
+                    "2026-03-31T08:00",
+                    "2026-03-31T09:00",
+                    "2026-03-31T10:00",
+                )
+            )
+        )
 
         result = build_reports_with_metadata(
             gpx_path=FIXTURE,
@@ -219,37 +227,7 @@ class ForecastEngineTests(unittest.TestCase):
         self.assertIn("3-day forecast horizon", result.skipped_comparisons[0].reason)
 
     def test_build_reports_skips_comparison_provider_on_api_error(self) -> None:
-        def handler(request: httpx.Request) -> httpx.Response:
-            if request.url.host == "api.open-meteo.com":
-                payload = {
-                    "hourly": {
-                        "time": [
-                            "2026-03-28T08:00",
-                            "2026-03-28T09:00",
-                            "2026-03-28T10:00",
-                        ],
-                        "temperature_2m": [8, 10, 12],
-                        "apparent_temperature": [7, 9, 11],
-                        "wind_speed_10m": [12, 15, 18],
-                        "wind_gusts_10m": [18, 22, 25],
-                        "wind_direction_10m": [270, 280, 290],
-                        "cloud_cover": [25, 35, 45],
-                        "precipitation": [0.0, 0.2, 0.4],
-                        "precipitation_probability": [10, 35, 60],
-                    }
-                }
-                latitudes = request.url.params["latitude"].split(",")
-                return httpx.Response(200, json=[payload for _ in latitudes])
-
-            if request.url.host == "api.weatherapi.com":
-                return httpx.Response(
-                    401,
-                    json={"error": {"code": 2006, "message": "API key is invalid."}},
-                )
-
-            raise AssertionError(f"Unexpected forecast host: {request.url.host}")
-
-        client = httpx.Client(transport=httpx.MockTransport(handler))
+        client = self.build_open_meteo_client(weatherapi_status_code=401)
 
         result = build_reports_with_metadata(
             gpx_path=FIXTURE,

--- a/tests/test_forecast_weather.py
+++ b/tests/test_forecast_weather.py
@@ -6,6 +6,7 @@ from urllib.parse import parse_qs, urlparse
 
 import httpx
 
+from trailintel.forecast.errors import WeatherAPIError
 from trailintel.forecast.models import SamplePoint
 from trailintel.forecast.weather import MetNoClient, OpenMeteoClient, WeatherAPIClient
 
@@ -191,6 +192,26 @@ class ForecastWeatherTests(unittest.TestCase):
         self.assertEqual(forecasts[0].apparent_temperature_c[0], 6.0)
         self.assertEqual(forecasts[0].wind_gust_kph[1], 19.0)
         self.assertEqual(forecasts[0].precipitation_probability[1], 20.0)
+
+    def test_weatherapi_client_surfaces_http_error_message(self) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                401,
+                json={"error": {"code": 2006, "message": "API key is invalid."}},
+            )
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        service = WeatherAPIClient(
+            http_client=client,
+            api_key="test-key",
+            request_interval_seconds=0.0,
+        )
+
+        with self.assertRaisesRegex(
+            WeatherAPIError,
+            "HTTP 401: API key is invalid",
+        ):
+            service.fetch_hourly([make_sample(0)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

This PR makes forecast comparison providers best-effort instead of fatal.

- validate the ride window against the primary provider only
- skip comparison providers when their forecast horizon cannot cover the ride
- skip comparison providers when provider-specific API or credential failures occur
- surface upstream provider error messages in CLI and bundle output
- include skipped comparison warnings in the HTML bundle and CLI output
- add regression tests covering horizon skips, WeatherAPI HTTP error messaging, and comparison-provider fallback behavior

## Why

Long-range forecasts were being blocked by the shortest comparison provider horizon. In practice, `open-meteo` could satisfy the ride window while `weatherapi` or `met-no` could not, but the whole run still failed.

A second issue was that WeatherAPI failures only surfaced as generic HTTP errors, which made it hard to distinguish a provider-side key/account problem from a forecasting bug.

## Impact

Users can still generate the primary forecast when optional comparison providers are unavailable, out of horizon, or failing. When a provider is skipped, the reason is shown in the CLI and the generated bundle.

## Validation

- `uv run python -m unittest discover -s tests -p 'test_forecast*.py'`
- `uv run --with ruff ruff check src/trailintel/forecast tests/test_forecast_weather.py tests/test_forecast_engine.py tests/test_forecast_bundle.py tests/test_forecast_cli.py`
- manual forecast runs with comparison providers to confirm successful output plus provider skip warnings
