### PR TITLE
Add deployed smoke test for PWA publish

### DIFF
--- a/.github/workflows/deploy-pwa.yml
+++ b/.github/workflows/deploy-pwa.yml
@@ -88,3 +88,14 @@ jobs:
           fi
           git commit -m "Publish TrailIntel Forecast PWA"
           git push origin "$branch"
+
+      - name: Install Chromium for deployed smoke test
+        working-directory: web
+        run: npx playwright install --with-deps chromium
+
+      - name: Smoke test deployed PWA
+        working-directory: web
+        run: |
+          npm run smoke:deployed -- \
+            --url "https://mpaladin.com/forecast/" \
+            --gpx "../tests/fixtures/sample_route.gpx"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ npm run test
 npm run build
 ```
 
+Smoke-test the deployed PWA against the public site:
+
+```bash
+cd /path/to/trailintel/web
+npm run build
+npx playwright install chromium
+npm run smoke:deployed -- --url https://mpaladin.com/forecast/ --gpx ../tests/fixtures/sample_route.gpx
+```
+
 ## Usage
 
 ### Forecast CLI
@@ -387,6 +396,7 @@ Published Pages layout:
 The PWA deploy workflow is separate from the report-publishing workflows and is intended for maintainers with the required repository secrets:
 
 - `.github/workflows/deploy-pwa.yml` builds `web/` and publishes it into `mpaladin/website` under `forecast/`
+- after publishing, the same workflow installs Chromium and runs a live smoke test against `https://mpaladin.com/forecast/`
 - required config for the PWA deploy workflow:
   - `WEBSITE_REPO`: target site repo, for example `mpaladin/website`
   - `WEBSITE_BRANCH`: target branch, for example `gh-pages`

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,6 +17,7 @@
         "@types/leaflet": "^1.9.15",
         "@types/node": "^22.10.1",
         "jsdom": "^25.0.1",
+        "playwright": "^1.59.1",
         "typescript": "^5.6.3",
         "vite": "^8.0.7",
         "vitest": "^4.1.3"
@@ -1596,6 +1597,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "smoke:deployed": "node scripts/smoke-deployed-pwa.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
@@ -21,6 +22,7 @@
     "@types/leaflet": "^1.9.15",
     "@types/node": "^22.10.1",
     "jsdom": "^25.0.1",
+    "playwright": "^1.59.1",
     "typescript": "^5.6.3",
     "vite": "^8.0.7",
     "vitest": "^4.1.3"

--- a/web/scripts/smoke-deployed-pwa.mjs
+++ b/web/scripts/smoke-deployed-pwa.mjs
@@ -1,0 +1,171 @@
+import { readFile } from "node:fs/promises";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { chromium } from "playwright";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const WEB_DIR = dirname(SCRIPT_DIR);
+const REPO_ROOT = dirname(WEB_DIR);
+const DEFAULT_URL = "https://mpaladin.com/forecast/";
+const DEFAULT_GPX = resolve(REPO_ROOT, "tests/fixtures/sample_route.gpx");
+const WAIT_INTERVAL_MS = 5_000;
+const DEFAULT_WAIT_TIMEOUT_MS = 180_000;
+const DEFAULT_PAGE_TIMEOUT_MS = 120_000;
+
+function parseArgs(argv) {
+  const options = {
+    url: DEFAULT_URL,
+    gpx: DEFAULT_GPX,
+    waitTimeoutMs: DEFAULT_WAIT_TIMEOUT_MS,
+    pageTimeoutMs: DEFAULT_PAGE_TIMEOUT_MS,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = argv[index];
+    if (current === "--url") {
+      options.url = argv[index + 1] ?? options.url;
+      index += 1;
+      continue;
+    }
+    if (current === "--gpx") {
+      options.gpx = resolve(process.cwd(), argv[index + 1] ?? options.gpx);
+      index += 1;
+      continue;
+    }
+    if (current === "--wait-timeout-ms") {
+      options.waitTimeoutMs = Number(argv[index + 1] ?? options.waitTimeoutMs);
+      index += 1;
+      continue;
+    }
+    if (current === "--page-timeout-ms") {
+      options.pageTimeoutMs = Number(argv[index + 1] ?? options.pageTimeoutMs);
+      index += 1;
+    }
+  }
+
+  if (!options.url.endsWith("/")) {
+    options.url += "/";
+  }
+  return options;
+}
+
+function readExpectedAssets(indexHtml) {
+  const jsMatch = indexHtml.match(/src="\.\/assets\/([^"]+\.js)"/);
+  const cssMatch = indexHtml.match(/href="\.\/assets\/([^"]+\.css)"/);
+  if (!jsMatch || !cssMatch) {
+    throw new Error("Could not determine expected asset names from web/dist/index.html");
+  }
+  return {
+    jsAsset: jsMatch[1],
+    cssAsset: cssMatch[1],
+  };
+}
+
+async function waitForLiveAssets(url, expectedAssets, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const response = await fetch(url, {
+      headers: {
+        "user-agent": "trailintel-deployed-smoke/0.1",
+      },
+    });
+    if (response.ok) {
+      const body = await response.text();
+      if (
+        body.includes(expectedAssets.jsAsset) &&
+        body.includes(expectedAssets.cssAsset)
+      ) {
+        return;
+      }
+    }
+    await new Promise((resolveDelay) => {
+      setTimeout(resolveDelay, WAIT_INTERVAL_MS);
+    });
+  }
+
+  throw new Error(
+    `Timed out waiting for ${expectedAssets.jsAsset} and ${expectedAssets.cssAsset} at ${url}`,
+  );
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const indexHtml = await readFile(resolve(WEB_DIR, "dist/index.html"), "utf-8");
+  const expectedAssets = readExpectedAssets(indexHtml);
+  await waitForLiveAssets(options.url, expectedAssets, options.waitTimeoutMs);
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1900 } });
+  const consoleMessages = [];
+  const pageErrors = [];
+
+  page.on("console", (message) => {
+    consoleMessages.push(`${message.type()}: ${message.text()}`);
+  });
+  page.on("pageerror", (error) => {
+    pageErrors.push(String(error));
+  });
+
+  try {
+    await page.goto(options.url, {
+      waitUntil: "networkidle",
+      timeout: options.pageTimeoutMs,
+    });
+    await page.setInputFiles("#gpx-input", options.gpx);
+    await page.click("#generate-button");
+    await page.waitForSelector("text=Forecast Report", {
+      timeout: options.pageTimeoutMs,
+    });
+    await page.waitForSelector("text=uPlot Forecast Charts", {
+      timeout: options.pageTimeoutMs,
+    });
+    await page.waitForSelector("text=OpenStreetMap Overview", {
+      timeout: options.pageTimeoutMs,
+    });
+    await page.waitForFunction(
+      () => document.querySelectorAll(".uplot").length >= 6,
+      null,
+      { timeout: options.pageTimeoutMs },
+    );
+    await page.waitForFunction(
+      () => !!document.querySelector(".leaflet-container"),
+      null,
+      { timeout: options.pageTimeoutMs },
+    );
+
+    const reportTitle = await page.locator(".report-hero h2").textContent();
+    const statusText = await page.locator("#status-panel").textContent();
+    const chartHeadings = await page
+      .locator(".forecast-chart-card h3")
+      .allTextContents();
+    const mapNote = await page.locator("#forecast-map-note").textContent();
+    const chartCount = await page.locator(".uplot").count();
+
+    if (pageErrors.length) {
+      throw new Error(`Browser page errors: ${pageErrors.join(" | ")}`);
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          url: options.url,
+          reportTitle,
+          statusText,
+          chartCount,
+          chartHeadings,
+          mapNote,
+          expectedAssets,
+          consoleMessages,
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    await browser.close();
+  }
+}
+
+await main();

--- a/web/src/ui/forecastMap.ts
+++ b/web/src/ui/forecastMap.ts
@@ -97,7 +97,8 @@ export async function mountForecastMap(report: ForecastReport): Promise<void> {
       resolved = true;
       fallback.hidden = true;
       container.hidden = false;
-      note.textContent = "CARTO Voyager tiles with route overlays and wind-direction arrows.";
+      note.textContent =
+        "CARTO Voyager tiles on an OpenStreetMap-style basemap with route overlays and wind-direction arrows.";
       window.setTimeout(() => activeMap?.invalidateSize(), 0);
     }
   });


### PR DESCRIPTION
## Summary
- add a Playwright-based smoke test for the deployed forecast PWA
- run that smoke test at the end of `.github/workflows/deploy-pwa.yml`
- update the live map success note to mention the OpenStreetMap-style basemap
- document the deployed smoke-test command in the README

## What changed
- added `web/scripts/smoke-deployed-pwa.mjs`
- added `npm run smoke:deployed`
- added `playwright` as a web dev dependency
- updated `deploy-pwa.yml` to install Chromium and smoke-test `https://mpaladin.com/forecast/` after publish
- refreshed the PWA map note wording in `web/src/ui/forecastMap.ts`

## Verification
- `cd web && npm run build`
- `cd web && npm run smoke:deployed -- --url https://mpaladin.com/forecast/ --gpx ../tests/fixtures/sample_route.gpx`
- local preview smoke test also passed

## Notes
- this keeps the existing publish path, but adds an end-to-end verification step so the workflow checks the live site after deployment
